### PR TITLE
updates spring version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.6.4'
+	id 'org.springframework.boot' version '2.6.6'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }


### PR DESCRIPTION
Fixes Spring4Shell vulnerability by upgrading to Spring 2.6.6